### PR TITLE
phpactor BC broke completionformat in develoment branch

### DIFF
--- a/rplugin/python3/deoplete/source/phpactor.py
+++ b/rplugin/python3/deoplete/source/phpactor.py
@@ -63,17 +63,24 @@ class Source(Base):
             return self.print_error(errs)
 
         result = json.loads(result.decode())
+
         result = result['parameters']['value']
 
-        if len(result['issues']) > 0:
-            self.vim.call(
-                'deoplete#util#print_error',
-                ', '.join(result['issues']),
-                'deoplete-phpactor'
-            )
+        if 'issues' in result:
+            if len(result['issues']) > 0:
+                self.vim.call(
+                    'deoplete#util#print_error',
+                    ', '.join(result['issues']),
+                    'deoplete-phpactor'
+                )
 
-        if len(result['suggestions']) > 0:
-            for suggestion in result['suggestions']:
+        if isinstance(result, list):
+            suggestions = result
+        else:
+            suggestions = result['suggestions']
+
+        if len(suggestions) > 0:
+            for suggestion in suggestions:
                 candidates.append({
                     'word': suggestion['name'],
                     'menu': suggestion['info'],


### PR DESCRIPTION
After updating phpactor (develop-branch) today I noticed that the completion response keys where depricated. see: https://github.com/phpactor/phpactor/blob/develop/CHANGELOG.md
So I managed to make a workaround for this issue. Maybe useful for others to?