### PR TITLE
Fixed error when no results were present.

### DIFF
--- a/rplugin/python3/deoplete/source/phpactor.py
+++ b/rplugin/python3/deoplete/source/phpactor.py
@@ -64,6 +64,9 @@ class Source(Base):
 
         result = json.loads(result.decode())
 
+        if 'parameters' not in result or 'value' not in result['parameters']:
+            return candidates
+
         result = result['parameters']['value']
 
         if 'issues' in result:


### PR DESCRIPTION
When the result dictionary would not have parameters or value keys
present a disruptive error would be shown while typing. I've added an
early return that will just back out silently if these values are not
present. This will not prevent completion from working.

Behavior before:

![ezgif-4-e34849dad6ea](https://user-images.githubusercontent.com/17016423/53243627-28c7dc80-366e-11e9-969e-d4e090b88ce9.gif)


Behavior now:

![ezgif-4-9f66cb76a483](https://user-images.githubusercontent.com/17016423/53243637-367d6200-366e-11e9-8e6f-ef3f08d19cb0.gif)
